### PR TITLE
Fix typo in test output

### DIFF
--- a/en/testing/unit_testing/README.md
+++ b/en/testing/unit_testing/README.md
@@ -46,7 +46,7 @@ func Test_HelloWorld(t *testing.T) {
 	exp := "Hello World"
 	act := res.Body.String()
 	if exp != act {
-		t.Fatalf("Expected %s gog %s", exp, act)
+		t.Fatalf("Expected %s got %s", exp, act)
 	}
 }
 ```

--- a/en/testing/unit_testing/example_test.go
+++ b/en/testing/unit_testing/example_test.go
@@ -18,6 +18,6 @@ func Test_HelloWorld(t *testing.T) {
 	exp := "Hello World"
 	act := res.Body.String()
 	if exp != act {
-		t.Fatalf("Expected %s gog %s", exp, act)
+		t.Fatalf("Expected %s got %s", exp, act)
 	}
 }


### PR DESCRIPTION
It should read 'got', not 'gog'